### PR TITLE
Make soft mode more loose

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This method validates if the given value is a valid `Social Security Number`.
 
 1. `value` *(&#42;)*: The value to validate.
 2. `[options]` *(Object)*: The options object.
-3. `[options.strict=true]` _(boolean)_: Whether or not formatting characters such as dashes or spaces should be rejected.
+3. `[options.strict=true]` _(boolean|string)_: Whether or not formatting characters such as dashes or spaces should be rejected and if they must be in their precise location.
 
 #### Returns
 *(boolean)*:  Returns `true` if `value` is a valid Social Security Number, else `false`.
@@ -31,10 +31,16 @@ This method validates if the given value is a valid `Social Security Number`.
 isValid({});
 // => false
 
-isValid('123-123-123');
+isValid('123-12-3123');
 // => false
 
-isValid('123-123-123', { strict: false });
+isValid('1-2-3123123', { strict: false });
+// => true
+
+isValid('1-2-3123123', { strict: 'format' });
+// => false
+
+isValid('123-12-3123', { strict: 'format' });
 // => true
 
 isValid('123123123');
@@ -50,7 +56,7 @@ This method will help you protect this sensitive piece of information by obfusca
 
 1. `value` *(&#42;)*: The value to mask.
 2. `[options]` *(Object)*: The options object.
-3. `[options.strict=true]` _(boolean)_: Whether or not formatting characters such as dashes or spaces should be rejected.
+3. `[options.strict=true]` _(boolean|string)_: Whether or not formatting characters such as dashes or spaces should be rejected and if they must be in their precise location.
 
 #### Returns
 *(string)*: Returns the masked value.
@@ -60,14 +66,20 @@ This method will help you protect this sensitive piece of information by obfusca
 mask({});
 // Throws an Error.
 
-mask('123-123-123');
+mask('123-12-3123');
 // Throws an Error.
 
-mask('123-123-123', { strict: false });
-// => XXX-X23-123
+mask('1-2-3123123', { strict: false });
+// => X-X-XXX3123
+
+mask('1-2-3123123', { strict: 'format' });
+// Throws an Error.
+
+mask('123-12-3123', { strict: 'format' });
+// => XXX-XX-3123
 
 mask('123123123');
-// => XXXX23123
+// => XXXXX3123
 ```
 
 * * *

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const blacklist = ['078051120', '219099999', '457555462'];
  */
 
 const expressions = {
-  soft: /^(?!666|000|9\d{2})\d{3}[- ]+?(?!00)\d{2}[- ]+?(?!0{4})\d{4}$/,
+  format: /^(?!666|000|9\d{2})\d{3}[- ]{0,1}(?!00)\d{2}[- ]{0,1}(?!0{4})\d{4}$/,
   strict: /^(?!666|000|9\d{2})\d{3}(?!00)\d{2}(?!0{4})\d{4}$/
 };
 
@@ -26,8 +26,9 @@ const expressions = {
  * Validate function.
  */
 
-export function isValid(ssn, { strict = true } = {}) {
-  const mode = strict === true ? 'strict' : 'soft';
+export function isValid(value, { strict = true } = {}) {
+  const mode = typeof strict === 'boolean' ? 'strict' : 'format';
+  const ssn = strict === false ? value.replace(/[- ]/g, '') : value;
 
   if (!expressions[mode].test(ssn)) {
     return false;


### PR DESCRIPTION
Previously, oddly formatted SSNs such as 12-123-1234 would not be allowed in soft/loose mode.

This patch corrects this behaviour so that any combination of dashes or spaces between those digits is allowed. The only requirement is that the resulting number combination is actually a valid SSN.
